### PR TITLE
Display OpenStreetMap element URIs like Wikidata entity URIs

### DIFF
--- a/wikibase/queryService/ui/resultBrowser/helper/FormatterHelper.js
+++ b/wikibase/queryService/ui/resultBrowser/helper/FormatterHelper.js
@@ -262,14 +262,15 @@ wikibase.queryService.ui.resultBrowser.helper.FormatterHelper = ( function( $, m
 	};
 
 	/**
-	 * Checks if a given URI appears to be a canonical Wikidata entity URI.
+	 * Checks if a given URI appears to be a canonical Wikidata entity, OpenStreetMap
+	 * Wiki entity, or OpenStreetMap element URI.
 	 *
 	 * @param {string} uri
 	 * @return {boolean}
 	 */
 	SELF.prototype.isEntityUri = function( uri ) {
 		return typeof uri === 'string'
-			&& /\/entity\/(Q|P|L|M)[0-9]+$/.test( uri );
+			&& /\/entity\/(Q|P|L|M)[0-9]+|\/(?:node|way|relation)\/[0-9]+$/.test( uri );
 	};
 
 	/**


### PR DESCRIPTION
Display OpenStreetMap element URIs the same way as Wikidata entity URIs in the tree, tree map, and bubble chart result views and sort them numerically in the table view.

Fixes Sophox/sophox#21.