### PR TITLE
Change examples wiki page name

### DIFF
--- a/wikibase/queryService/api/QuerySamples.js
+++ b/wikibase/queryService/api/QuerySamples.js
@@ -113,7 +113,7 @@ wikibase.queryService.api.QuerySamples = ( function ( $ ) {
 
 			if ( data.parts && data.parts[0].template ) {
 				templateHref = data.parts[0].template.target.href;
-				if ( templateHref === './Template:SPARQL' || templateHref === './Template:SPARQL2' ) {
+				if ( templateHref === './Template:Sophox' || templateHref === './Template:SPARQL' || templateHref === './Template:SPARQL2' ) {
 					// SPARQL/SPARQL2 template
 					query = data.parts[0].template.params.query.wt;
 				} else {
@@ -181,7 +181,7 @@ return class extends SuperClass {
     super(lang);
     this._apiServer = 'https://wiki.openstreetmap.org/';
     this._apiEndpoint = this._apiServer + 'w/api.php';
-    this._pageTitle = encodeURIComponent('SPARQL_examples');
+    this._pageTitle = encodeURIComponent('Sophox/Example_queries/Raw');
     this._pageUrl = this._apiServer + 'wiki/' + this._pageTitle;
   }
 


### PR DESCRIPTION
Currently example queries on Sophox are fetched from the OSM wiki page `SPARQL examples` and assuming queries are inside `Template:SPARQL` or `Template:SPARQL2`.  Given that Sophox is not the only SPARQL available we intend to move [`SPARQL examples`](https://wiki.openstreetmap.org/w/index.php?title=SPARQL_examples&redirect=no) to [`Sophox/Example queries/Raw`](https://wiki.openstreetmap.org/wiki/Sophox/Example_queries/Raw) (which will be transcluded into [`Sophox/Example queries`](https://wiki.openstreetmap.org/wiki/Sophox/Example_queries) for consultation) and move [`Template:SPARQL`](https://wiki.openstreetmap.org/w/index.php?title=Template:SPARQL&redirect=no) to [`Template:Sophox`](https://wiki.openstreetmap.org/w/index.php?title=Template:Sophox&redirect=no).

The changes in this pull request reflect these changes